### PR TITLE
Split vulkan-docs image 

### DIFF
--- a/Dockerfile.vulkan-docs
+++ b/Dockerfile.vulkan-docs
@@ -14,74 +14,8 @@
 
 # This is a Docker container for Vulkan specification builds
 
-from ruby:2.7
+from khronosgroup/docker-images:vulkan-docs-base
 label maintainer="Jon Leech <devrel@oddhack.org>"
-
-# This adds the Node.js repository to the apt registry
-# nodejs is actually installed in the next step
-run curl -sL https://deb.nodesource.com/setup_12.x | bash -
-
-# Install required Debian packages
-run apt-get update -qq && \
-    apt-get install -y -qq --no-install-recommends \
-        bash \
-        bison  \
-        build-essential \
-        cmake \
-        flex \
-        fonts-lyx \
-        clang \
-        gcc \
-        ghostscript \
-        git \
-        gosu \
-        g++ \
-        jing \
-        libavalon-framework-java \
-        libbatik-java \
-        libcairo2-dev \
-        libffi-dev \
-        libgdk-pixbuf2.0-dev \
-        libpango1.0-dev \
-        libreadline-dev \
-        libxml2-dev \
-        nodejs \
-        pdftk \
-        poppler-utils \
-        python3 \
-        python3-pytest \
-        python3-termcolor \
-        tcsh && \
-    apt-get clean && \
-    gem install \
-        asciidoctor \
-        asciidoctor-diagram \
-        asciidoctor-mathematical \
-        asciidoctor-pdf \
-        coderay \
-        json-schema \
-        i18n
-
-# Install chunked index generation scripts and add lunr to node searchpath
-run npm install -g escape-string-regexp he lunr@2.3.6
-env NODE_PATH /usr/lib/node_modules
-
-# Install Roswell and asciidoctor-chunker. Need at least this specific
-# version (later may be OK, too). There seems to be no roswell APT
-# repository.
-run curl -fsSL -o roswell.deb https://github.com/roswell/roswell/releases/download/v20.01.14.104/roswell_20.01.14.104-1_amd64.deb && \
-    dpkg -i roswell.deb && \
-    ros install alexandria lquery cl-fad && \
-    mkdir -p $HOME/common-lisp && \
-    (cd $HOME/common-lisp && git clone https://github.com/wshito/asciidoctor-chunker.git)
-
-# Ensure the proper locale is installed and used - not present in ruby image
-# See https://serverfault.com/questions/54591/how-to-install-change-locale-on-debian#54597
-run apt-get install -y -qq locales && \
-    sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && \
-    locale-gen && \
-    apt-get clean
-env LANG en_US.UTF-8
 
 # Add the entrypoint to the image, and ensure files installed in root (under
 # .roswell/ and common-lisp/) are accessible by the entrypoint when run as

--- a/Dockerfile.vulkan-docs-base
+++ b/Dockerfile.vulkan-docs-base
@@ -1,0 +1,84 @@
+# Copyright (c) 2019-2020 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a Docker container for Vulkan specification builds
+
+from ruby:2.7
+label maintainer="Jon Leech <devrel@oddhack.org>"
+
+# This adds the Node.js repository to the apt registry
+# nodejs is actually installed in the next step
+run curl -sL https://deb.nodesource.com/setup_12.x | bash -
+
+# Install required Debian packages
+run apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        bash \
+        bison  \
+        build-essential \
+        cmake \
+        flex \
+        fonts-lyx \
+        clang \
+        gcc \
+        ghostscript \
+        git \
+        gosu \
+        g++ \
+        jing \
+        libavalon-framework-java \
+        libbatik-java \
+        libcairo2-dev \
+        libffi-dev \
+        libgdk-pixbuf2.0-dev \
+        libpango1.0-dev \
+        libreadline-dev \
+        libxml2-dev \
+        nodejs \
+        pdftk \
+        poppler-utils \
+        python3 \
+        python3-pytest \
+        python3-termcolor \
+        tcsh && \
+    apt-get clean && \
+    gem install \
+        asciidoctor \
+        asciidoctor-diagram \
+        asciidoctor-mathematical \
+        asciidoctor-pdf \
+        coderay \
+        json-schema \
+        i18n
+
+# Install chunked index generation scripts and add lunr to node searchpath
+run npm install -g escape-string-regexp he lunr@2.3.6
+env NODE_PATH /usr/lib/node_modules
+
+# Install Roswell and asciidoctor-chunker. Need at least this specific
+# version (later may be OK, too). There seems to be no roswell APT
+# repository.
+run curl -fsSL -o roswell.deb https://github.com/roswell/roswell/releases/download/v20.01.14.104/roswell_20.01.14.104-1_amd64.deb && \
+    dpkg -i roswell.deb && \
+    ros install alexandria lquery cl-fad && \
+    mkdir -p $HOME/common-lisp && \
+    (cd $HOME/common-lisp && git clone https://github.com/wshito/asciidoctor-chunker.git)
+
+# Ensure the proper locale is installed and used - not present in ruby image
+# See https://serverfault.com/questions/54591/how-to-install-change-locale-on-debian#54597
+run apt-get install -y -qq locales && \
+    sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && \
+    locale-gen && \
+    apt-get clean
+env LANG en_US.UTF-8


### PR DESCRIPTION
into "base" image that has no entrypoint script and existing image that adds the script. Should enable #7. @rpavlik it seemed obvious how to do the split, although if you have suggestions they're welcome.