### PR TITLE
Add dockerfile for Rust container + setup

### DIFF
--- a/.azure-pipelines/all-images.yml
+++ b/.azure-pipelines/all-images.yml
@@ -31,6 +31,13 @@ steps:
       tag: openxr-pregenerated-sdk
       version: 202201
 
+  # Rust bindings-generator builder
+  - template: build-template.yml
+    parameters:
+      command: ${{ parameters.command }}
+      tag: rust
+      version: 202206
+
   # This image build is broken right now: E: Package 'ttf-lyx' has no installation candidate
   # - template: build-template.yml
   #   parameters:

--- a/build-all.sh
+++ b/build-all.sh
@@ -9,6 +9,7 @@ set -e
     ./build-one.sh asciidoctor-spec 202206 "$@"
     ./build-one.sh vulkan-docs-base 202206 "$@"
     ./build-one.sh vulkan-docs 202206 "$@"
+    ./build-one.sh rust 202206 "$@"
     ./build-one.sh openxr-base 202110 "$@"
     ./build-one.sh openxr 202110 "$@"
     ./build-one.sh openxr-sdk 202110 "$@"

--- a/rust.Dockerfile
+++ b/rust.Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2019-2022 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This defines a docker image for generating and buld-testing
+# Rust bindings to the Vulkan API.
+
+FROM rust:latest
+LABEL maintainer="Marijn Suijten <marijn@traverseresearch.nl>"
+
+# Git for cloning repos, libclang-dev for running bindgen
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+    git \
+    libclang-dev
+
+# Preinstall additional Rust tools needed to clean and lint
+# generated bindings
+RUN rustup component add rustfmt clippy


### PR DESCRIPTION
Now that we're progressing towards build-testing Rust bindings in the Khronos CI, a minimal docker image with Rust support and few other dependencies is needed to make this possible.
