### PR TITLE
Remove `.latest` suffix from tag names

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -16,6 +16,6 @@ steps:
       command: ${{ parameters.command }}
       arguments: "--build-arg \"VERSION=${{ parameters.version }}\""
       tags: |
-        ${{ parameters.tag }}.latest
+        ${{ parameters.tag }}
         ${{ parameters.tag }}.${{ parameters.version }}
       Dockerfile: ${{ parameters.tag }}.Dockerfile

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ repository https://hub.docker.com/r/khronosgroup/docker-images.
 ## Structure
 
 Each Dockerfile is named `<tag>.Dockerfile` where `<tag>` (e.g. `openxr`, `asciidoctor-spec`)
-matches the tag for that image in the Dockerhub repository, suffixed with both `-latest` for the
-latest revision of this image, and `-<date>` representing a timestamp when this image was last
-modified.
+matches the tag for that image in the Dockerhub repository (e.g. `KhronosGroup/docker-images:rust`).
+A second tag is suffixed with `.<date>` representing a timestamp when this image was last modified.
 
 ## Scripts
 

--- a/build-one.sh
+++ b/build-one.sh
@@ -25,10 +25,10 @@ REPO="khronosgroup/docker-images"
     fi
     docker build "$@" . -f "$DOCKERFILE.Dockerfile" \
         --build-arg "VERSION=$VERSION" \
-        -t "$REPO:$DOCKERFILE.latest" \
+        -t "$REPO:$DOCKERFILE" \
         -t "$REPO:$DOCKERFILE.$VERSION"
     if [ "$OP" == "push" ]; then
-        docker push "$REPO:$DOCKERFILE.latest"
+        docker push "$REPO:$DOCKERFILE"
         docker push "$REPO:$DOCKERFILE.$VERSION"
     fi
 )


### PR DESCRIPTION
This suffix is pretty nonstandard, and looks ugly.  Typically `latest` is used as the sole value of a tag given that the "type" of an image is already covered in the "repo" part of the name (i.e.  `KhronosGroup/$DOCKERFILE:latest`).  `.$VERSION` remains as that is what is already actively used.

Over time we can hopefully switch to the `KhronosGroup/$DOCKERFILE:latest` + `KhronosGroup/$DOCKERFILE:$VERSION` format across all images.
