### PR TITLE
Use repository name to identify individual images instead of tags

### DIFF
--- a/.azure-pipelines/all-images.yml
+++ b/.azure-pipelines/all-images.yml
@@ -9,37 +9,31 @@ steps:
   - template: build-template.yml
     parameters:
       command: ${{ parameters.command }}
-      tag: openxr-base
+      repo: openxr-base
       version: 202110
 
   - template: build-template.yml
     parameters:
       command: ${{ parameters.command }}
-      tag: openxr
+      repo: openxr
       version: 202110
 
   # OpenXR SDK builder
   - template: build-template.yml
     parameters:
       command: ${{ parameters.command }}
-      tag: openxr-sdk
+      repo: openxr-sdk
       version: 202110
 
   - template: build-template.yml
     parameters:
       command: ${{ parameters.command }}
-      tag: openxr-pregenerated-sdk
+      repo: openxr-pregenerated-sdk
       version: 202201
 
   # Rust bindings-generator builder
   - template: build-template.yml
     parameters:
       command: ${{ parameters.command }}
-      tag: rust
+      repo: rust
       version: 202206
-
-  # This image build is broken right now: E: Package 'ttf-lyx' has no installation candidate
-  # - template: build-template.yml
-  #   parameters:
-  #     command: ${{ parameters.command }}
-  #     tag: latest

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -3,19 +3,19 @@
 # See <https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/docker?view=azure-devops>
 
 parameters:
-  imageName: "khronosgroup/docker-images"
-  tag:
+  repoOwner: "khronosgroup"
+  repo:
   command: build
   version:
 
 steps:
   - task: Docker@2
-    displayName: ${{ parameters.command }} ${{ parameters.tag }} ${{ parameters.version }}
+    displayName: ${{ parameters.command }} ${{ parameters.repo }} @ ${{ parameters.version }}
     inputs:
-      repository: ${{ parameters.imageName }}
+      repository: "${{ parameters.repoOwner }}/${{ parameters.repo }}"
       command: ${{ parameters.command }}
-      arguments: "--build-arg \"VERSION=${{ parameters.version }}\""
+      arguments: '--build-arg "VERSION=${{ parameters.version }}"'
       tags: |
-        ${{ parameters.tag }}.latest
-        ${{ parameters.tag }}.${{ parameters.version }}
-      Dockerfile: ${{ parameters.tag }}.Dockerfile
+        latest
+        ${{ parameters.version }}
+      Dockerfile: ${{ parameters.repo }}.Dockerfile

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ repository https://hub.docker.com/r/khronosgroup/docker-images.
 
 ## Structure
 
-Each Dockerfile is named `<tag>.Dockerfile` where `<tag>` (e.g. `openxr`, `asciidoctor-spec`)
-matches the tag for that image in the Dockerhub repository, suffixed with both `-latest` for the
-latest revision of this image, and `-<date>` representing a timestamp when this image was last
-modified.
+All Dockerfiles are named `<repo>.Dockerfile` where `<repo>` (e.g. `openxr`, `asciidoctor-spec`)
+is used in the repository name as `khronosgroup/<repo>`. Each image will be published with a `latest`
+tag and timestamp tag (typically year + month as `yyyymm`) dating when this image was last modified.
 
 ## Scripts
 
@@ -19,9 +18,9 @@ In general, any additional arguments are forwarded on to `docker build` except t
 `"push"`, so this is how you can pass `--no-cache` to force a rebuild, etc.
 
 - Single-image scripts: pass a tag name as the first argument and a version as the second.
-  - `./build-one.sh <tag> <date>` - Just builds and tags the image locally, does not push to Dockerhub.
+  - `./build-one.sh <repo> <date>` - Just builds and tags the image locally, does not push to Dockerhub.
     Use for testing modifications.
-  - `./build-one.sh <tag> <date> push` - Builds and tags the image locally, then pushes it to Dockerhub.
+  - `./build-one.sh <repo> <date> push` - Builds and tags the image locally, then pushes it to Dockerhub.
     Only run this once you've committed (and ideally, pushed) the corresponding changes to this Git repo.
 - `./build-all.sh` - Just calls `./build-one.sh` on all the tags listed in it. Use as `./build-all.sh push`
   to push all images to Dockerhub.

--- a/build-one.sh
+++ b/build-one.sh
@@ -8,11 +8,13 @@
 # Any extra arguments (including the third argument if it's not "push")
 # are passed to `docker build` literally.
 #
-# The tag portion of the name is used as the tag within the repo.
+# The name of the dockerfile is used in the repository of the image,
+# and the version argument - as well as the literal "latest" - end up
+# in the tag portion.
 
 set -e
 
-REPO="khronosgroup/docker-images"
+REPO_OWNER="khronosgroup"
 
 (
     cd $(dirname $0)
@@ -23,12 +25,13 @@ REPO="khronosgroup/docker-images"
         OP=$1
         shift
     fi
+    REPO=$REPO_OWNER/$DOCKERFILE
     docker build "$@" . -f "$DOCKERFILE.Dockerfile" \
         --build-arg "VERSION=$VERSION" \
-        -t "$REPO:$DOCKERFILE.latest" \
-        -t "$REPO:$DOCKERFILE.$VERSION"
+        -t "$REPO:latest" \
+        -t "$REPO:$VERSION"
     if [ "$OP" == "push" ]; then
-        docker push "$REPO:$DOCKERFILE.latest"
-        docker push "$REPO:$DOCKERFILE.$VERSION"
+        docker push "$REPO:latest"
+        docker push "$REPO:$VERSION"
     fi
 )


### PR DESCRIPTION
As discussed before the type of an image is better represented in the "repo" part of the name, leaving the tag purely for versioning (typically `latest`, and combinations of tags that represent a specific [combination of] versions that had been used to create the image).

This might not have been done previously due to quotas, but such limits don't seem to exist anymore.
