### PR TITLE
Rebuild Rust container on December 2023 with Rust 1.74

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -9,7 +9,7 @@ set -e
     ./build-one.sh asciidoctor-spec 202206 "$@"
     ./build-one.sh vulkan-docs-base 202206 "$@"
     ./build-one.sh vulkan-docs 202206 "$@"
-    ./build-one.sh rust 202206 "$@"
+    ./build-one.sh rust 202312 "$@"
     ./build-one.sh openxr 20231010.1 "$@"
     ./build-one.sh openxr-sdk 20230614 "$@"
     ./build-one.sh openxr-pregenerated-sdk 20230822 "$@"

--- a/rust.Dockerfile
+++ b/rust.Dockerfile
@@ -4,7 +4,7 @@
 # This defines a docker image for generating and buld-testing
 # Rust bindings to the Vulkan API.
 
-FROM rust:latest
+FROM rust:1.74
 LABEL maintainer="Marijn Suijten <marijn@traverseresearch.nl>"
 
 # Git for cloning repos, libclang-dev for running bindgen


### PR DESCRIPTION
Fixes https://github.com/ash-rs/ash/issues/847

The current image is quite dated and no longer adequate to compile `ash`. Our `rust:latest` base image tag is replaced with `1.74` to ensure a recent-enough Rust base container is used, instead of considering an _ancient_ local image/tag cache, as experience has shown.
