### PR TITLE
Add dos2unix tool for the SPIR-V workflow

### DIFF
--- a/asciidoctor-spec.Dockerfile
+++ b/asciidoctor-spec.Dockerfile
@@ -51,6 +51,7 @@ run apt-get update -qq && \
         python3-pytest \
         python3-termcolor \
         tcsh \
+        dos2unix \
     && apt-get clean
 
 # Ruby gems providing asciidoctor and related plugins


### PR DESCRIPTION
The SPIR-V specs and extension workflow uses the tools, adding this to the base image so it is usable by the group.