### PR TITLE
Add a reminder to build-one.sh push operations to cleanup after yourself

### DIFF
--- a/build-one.sh
+++ b/build-one.sh
@@ -42,12 +42,15 @@ REPO="khronosgroup/docker-images"
         echo
         echo "** To refer to this image precisely, use:"
         echo "   $REPO:$DOCKERFILE.$VERSION@$HASH"
+
+        echo "After pushing an image, it is a good idea to clean up build cache and"
+        echo "unused images using commands like 'docker buildx prune',"
+        echo "'docker image ls -a --digests', and 'docker image rmi'"
     else
         echo
         echo "** Not pushing, so no SHA256 manifest available. Until you push this image, refer to it as:"
         echo "   $REPO:$DOCKERFILE.$VERSION"
     fi
-
 
     [ -n "$CI" ] && echo "::endgroup::"
 )


### PR DESCRIPTION
Docker builds and old images can consume vast amounts of space quickly. This just prints out a reminder and suggests some steps to take to clean up after yourself once an image is pushed (but not when it's just built and not pushed).

@rpavlik let me know if OK.