### PR TITLE
Update clang format version to 14 for OpenXR.

### DIFF
--- a/openxr-sdk.Dockerfile
+++ b/openxr-sdk.Dockerfile
@@ -35,7 +35,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
     build-essential \
     ca-certificates \
     clang-10 \
-    clang-format-10 \
     cmake \
     git \
     git-lfs \

--- a/openxr.Dockerfile
+++ b/openxr.Dockerfile
@@ -72,7 +72,7 @@ COPY --from=builder /usr/local/ /usr/local/
 # Runtime-required packages
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
     env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y -qq \
-    clang-format-13 \
+    clang-format-14 \
     fonts-lyx \
     ghostscript \
     git \


### PR DESCRIPTION
Not available in focal 20.04 so we are switching which image does the clang-format.

Finally got tired of clang-format 10 differing from newer versions but being nearly impossible to install.